### PR TITLE
Delete "gitIgnore" file

### DIFF
--- a/.gitIgnore
+++ b/.gitIgnore
@@ -1,2 +1,0 @@
-node_modules
-dist


### PR DESCRIPTION
There are two files, one called gitignore and one called gitIgnore. This results in a warning message when cloning. I'd like to delete gitIgnore because it doesn't do anything except create a warning mesage.